### PR TITLE
Added removal callbacks, automatic removal for success and error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var classify = function(name) {
 var Loader = {
 
   options: {
-    className    : 'loader'
+    className    : 'loader',
+    removeAfter  : 500
   },
 
   init: function() {
@@ -25,38 +26,70 @@ var Loader = {
   },
   
   // Show loader with default loading message and style
-  loading: function ( message ) {
-    Loader.show( message || 'Hang tight…', 'loading' )
+  loading: function ( options ) {
+    options = Loader.setOptions( options, 'Hang tight…', 'loading' )
+    Loader.show( options )
   },
 
   // Show loader with success loading message and style
-  success: function ( message ) {
-    Loader.show( message || 'Got it!', 'success' )
+  success: function ( options ) {
+    options = Loader.setOptions( options, 'Got it!', 'success' )
+    if ( typeof options.removeAfter == 'undefined' ) options.removeAfter = Loader.options.removeAfter
+
+    Loader.show( options )
   },
 
   // Show loader with success failure message and style
-  failure: function ( message ) {
-    Loader.show( message || 'Hold up!', 'failure' )
+  failure: function ( options ) {
+    options = Loader.setOptions( options, 'Hold up!', 'failure' )
+    if ( typeof options.removeAfter == 'undefined' ) options.removeAfter = Loader.options.removeAfter
+
+    Loader.show( options )
   },
 
   // Base show loader function
-  show: function( message, className ) {
+  show: function( options ) {
 
     el = Loader.init()
 
-    el.textContent = message
+    el.textContent = options.message
     el.className = Loader.options.className
-    el.classList.add( className );
+    el.classList.add( options.className );
+
+    if ( options.removeAfter ) {
+
+      // Remove loader after timeout
+      setTimeout( function(){
+        requestAnimationFrame( Loader.remove( options.callback ) )
+      }, options.removeAfter )
+
+    }
 
   },
 
   // Hide loader icon function
-  remove: function() {
+  remove: function( callback ) {
 
     // Reset to base classname
     var el = Loader.element()
-    el.parentNode.removeChild(el)
 
+    requestAnimationFrame( function(){ 
+      el.parentNode.removeChild(el)
+      if ( typeof callback === 'function' ) callback()
+    })
+
+  },
+
+  setOptions: function ( options, message, className ) {
+    options = options || {}
+    if ( typeof options == 'string' ) {
+      options = { message: options }
+    }
+
+    options.message   = options.message   || message
+    options.className = options.className || className
+
+    return options
   }
 
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "compose-loader",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A simple system for displaying a loading indicator",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,7 @@ describe('Loader', function(){
 
   it('displays a failure state', function(){
 
-    Loader.failure()
+    Loader.failure( { removeAfter: false } )
 
     assert.equal( loaderEl().textContent, 'Hold up!' )
     assert.isTrue( loaderEl().classList.contains( 'failure' ) )
@@ -28,7 +28,7 @@ describe('Loader', function(){
 
   it('displays a success state', function(){
 
-    Loader.success()
+    Loader.success( { removeAfter: false } )
 
     assert.equal( loaderEl().textContent, 'Got it!' )
     assert.isTrue( loaderEl().classList.contains( 'success' ) )
@@ -46,7 +46,7 @@ describe('Loader', function(){
 
   it('displays a success custom show message', function(){
 
-    Loader.show( 'Test Message!', 'test-class' )
+    Loader.show( { message: 'Test Message!', className: 'test-class' } )
     assert.equal( loaderEl().textContent, 'Test Message!' )
     assert.isTrue( loaderEl().classList.contains( 'test-class' ) )
 
@@ -54,6 +54,18 @@ describe('Loader', function(){
 
   it('removes the loader when done', function() {
     Loader.remove()
-    assert.isNull(loaderEl())
+    requestAnimationFrame( function() { 
+      assert.isNull( loaderEl() )
+    })
+  })
+
+  it('automatically removes messages', function() {
+    Loader.success( { removeAfter: 30 } )
+
+    setTimeout( function() {
+      requestAnimationFrame( function() { 
+        assert.isNull( loaderEl() )
+      })
+    }, 30 )
   })
 })


### PR DESCRIPTION
Now you can call `Loader.success( { callback: someFunction } )` which will show the default message for `success` and then remove after 500ms and trigger the callback.

All options are…

```
{ 
  message: "",
  className: "",
  removeAfter: 500,
  callback: fn()
}
```

Only success and failure messages automatically dismiss after the set timer. Loading messages do not but you can pass the `removeAfter` option so that they will if you like.